### PR TITLE
CharLSTM architecture 

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -894,14 +894,13 @@ commands:
       - python -m spacy download de_core_news_lg
       - >-
         python -m spacy train
-        configs/ner_charlstm.cfg
+        configs/ner.cfg
         --output training/de-wikineural/ner/
         --paths.vectors de_core_news_lg
         --nlp.lang de
         --paths.train corpus/ner/de-wikineural-train.spacy
         --paths.dev corpus/ner/de-wikineural-dev.spacy
         --gpu-id ${vars.gpu_id}
-        --code scripts/char_lstm.py
       - >-
         python -m spacy train
         configs/spancat.cfg

--- a/scripts/char_lstm.py
+++ b/scripts/char_lstm.py
@@ -52,18 +52,18 @@ def to_unicode(doc: Doc, xp) -> Tuple[Ints1d, Ints1d, Ints1d]:
 def forward_docs2unicode(
     model: Model, docs: List[Doc], is_train: bool
 ) -> Tuple[List[Ints1d], List[Ints1d], List[Ints1d]]:
-    byte_list, start_list, end_list = [], [], []
+    unicodes_list, start_list, end_list = [], [], []
     xp = model.ops.xp
     for doc in docs:
-        unicode_data = to_unicode(doc, xp)
-        byte_list.append(unicode_data[0])
-        start_list.append(unicode_data[1])
-        end_list.append(unicode_data[2])
+        unicodes, starts, ends = to_unicode(doc, xp)
+        unicodes_list.append(unicodes)
+        start_list.append(starts)
+        end_list.append(ends)
 
     def backprop(dY):
         return []
 
-    return (byte_list, start_list, end_list), backprop
+    return (unicodes_list, start_list, end_list), backprop
 
 
 def forward_gather_tokens(


### PR DESCRIPTION
This PR implements the idea for character-level encoding from the `MetaLSTM` paper https://arxiv.org/pdf/1805.08237v1.pdf.  

It takes the `Doc` and converts into unicode codepoints with the built-in Python `ord` and adds a `" "` character between each token to show the word-boundary. Then it runs the `HashEmbed` layer to embed these codepoints to be able to run it across all the languages we consider. 

For each word it concatenates the representation from the `BiLSTM` at the first and last character.

It also implements an `IdentityEncoder`, which is a `noop` encoder to be able to use the `Tok2Vec` architecture. The character-lstm is the `embed` module and the `encoder` is just the `noop`.

With the `ner_charlstm.cfg` it gets up to `.63 F1` on  the development set during training.