### PR TITLE
Fix iconv command

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -482,40 +482,39 @@ commands:
         python -m spacy debug data configs/spancat_default.cfg 
         --paths.train corpus/spancat/de-wikineural-train.spacy 
         --paths.dev corpus/spancat/de-wikineural-dev.spacy
-      
+
       - >-
         python -m spacy debug data configs/spancat_default.cfg 
         --paths.train corpus/spancat/en-wikineural-train.spacy 
         --paths.dev corpus/spancat/en-wikineural-dev.spacy
-      
+
       - >-
         python -m spacy debug data configs/spancat_default.cfg 
         --paths.train corpus/spancat/es-wikineural-train.spacy 
         --paths.dev corpus/spancat/es-wikineural-dev.spacy
-      
+
       - >-
         python -m spacy debug data configs/spancat_default.cfg 
         --paths.train corpus/spancat/nl-wikineural-train.spacy 
         --paths.dev corpus/spancat/nl-wikineural-dev.spacy
-
 
   - name: "unpack-conll"
     help: "Decompress ConLL 2002, remove temporary files and change encoding."
     script:
       - mkdir temp
       - tar -xvf assets/conll.tgz -C temp
-      - gzip -d temp/ner/data/esp.testa.gz 
+      - gzip -d temp/ner/data/esp.testa.gz
       - gzip -d temp/ner/data/esp.testb.gz
       - gzip -d temp/ner/data/esp.train.gz
       - gzip -d temp/ner/data/ned.testa.gz
       - gzip -d temp/ner/data/ned.testb.gz
       - gzip -d temp/ner/data/ned.train.gz
-      - iconv -f iso-8859-1 temp/ner/data/esp.testa -o assets/es-conll-dev.iob
-      - iconv -f iso-8859-1 temp/ner/data/esp.testb -o assets/es-conll-test.iob
-      - iconv -f iso-8859-1 temp/ner/data/esp.train -o assets/es-conll-train.iob
-      - iconv -f iso-8859-1 temp/ner/data/ned.testa -o assets/nl-conll-dev.iob
-      - iconv -f iso-8859-1 temp/ner/data/ned.testb -o assets/nl-conll-test.iob
-      - iconv -f iso-8859-1 temp/ner/data/ned.train -o assets/nl-conll-train.iob
+      - iconv -f latin1 -t ascii//TRANSLIT temp/ner/data/esp.testa -o assets/es-conll-dev.iob
+      - iconv -f latin1 -t ascii//TRANSLIT temp/ner/data/esp.testb -o assets/es-conll-test.iob
+      - iconv -f latin1 -t ascii//TRANSLIT temp/ner/data/esp.train -o assets/es-conll-train.iob
+      - iconv -f latin1 -t ascii//TRANSLIT temp/ner/data/ned.testa -o assets/nl-conll-dev.iob
+      - iconv -f latin1 -t ascii//TRANSLIT temp/ner/data/ned.testb -o assets/nl-conll-test.iob
+      - iconv -f latin1 -t ascii//TRANSLIT temp/ner/data/ned.train -o assets/nl-conll-train.iob
       - rm -rf temp
       - rm assets/conll.tgz
     deps:

--- a/project.yml
+++ b/project.yml
@@ -133,9 +133,7 @@ assets:
   - dest: "assets/finer139.zip"
     url: "https://huggingface.co/datasets/nlpaueb/finer-139/resolve/main/finer139.zip"
 
-
 commands:
-
   - name: "preprocess-wnut17"
     help: "Canonicalize the WNUT2017 data set for conversion to .spacy."
     script:
@@ -150,7 +148,7 @@ commands:
       - assets/wnut17-train.iob
       - assets/wnut17-dev.iob
       - assets/wnut17-test.iob
-      
+
   - name: "convert-wnut17-ents"
     help: "Convert WNUT17 dataset into the spaCy format"
     script:
@@ -211,7 +209,7 @@ commands:
     help: "Remove unnecessary indices from wikineural data"
     script:
       # Clean Wikineural datasets
-      - >- 
+      - >-
         python -m scripts.preprocess
         assets/raw-de-wikineural-train.iob
         assets/de-wikineural-train.iob
@@ -231,7 +229,7 @@ commands:
         assets/raw-en-wikineural-train.iob
         assets/en-wikineural-train.iob
         --strip-digits
-      - >- 
+      - >-
         python -m scripts.preprocess
         assets/raw-en-wikineural-dev.iob
         assets/en-wikineural-dev.iob
@@ -241,7 +239,7 @@ commands:
         assets/raw-en-wikineural-test.iob
         assets/en-wikineural-test.iob
         --strip-digits
-      - >- 
+      - >-
         python -m scripts.preprocess
         assets/raw-es-wikineural-train.iob
         assets/es-wikineural-train.iob
@@ -251,17 +249,17 @@ commands:
         assets/raw-es-wikineural-dev.iob
         assets/es-wikineural-dev.iob
         --strip-digits
-      - >- 
+      - >-
         python -m scripts.preprocess
         assets/raw-es-wikineural-test.iob
         assets/es-wikineural-test.iob
         --strip-digits
-      - >- 
+      - >-
         python -m scripts.preprocess
         assets/raw-nl-wikineural-train.iob
         assets/nl-wikineural-train.iob
         --strip-digits
-      - >- 
+      - >-
         python -m scripts.preprocess
         assets/raw-nl-wikineural-dev.iob
         assets/nl-wikineural-dev.iob
@@ -474,7 +472,7 @@ commands:
       - "corpus/ner/nl-wikineural-train.spacy"
       - "corpus/ner/nl-wikineural-dev.spacy"
       - "corpus/ner/nl-wikineural-test.spacy"
-  
+
   - name: "inspect-wikineural"
     help: "Analyze span-characteristics"
     script:
@@ -527,7 +525,7 @@ commands:
       - assets/nl-conll-train.iob
       - assets/nl-conll-dev.iob
       - assets/nl-conll-test.iob
-  
+
   - name: "preprocess-conll"
     help: "Canonicalize the Dutch ConLL data set for conversion to .spacy."
     script:
@@ -636,7 +634,7 @@ commands:
       - "corpus/ner/nl-conll-train.spacy"
       - "corpus/ner/nl-conll-dev.spacy"
       - "corpus/ner/nl-conll-test.spacy"
-  
+
   - name: "inspect-conll"
     help: "Analyze span-characteristics"
     script:
@@ -688,7 +686,7 @@ commands:
       - "corpus/ner/archaeo-train.spacy"
       - "corpus/ner/archaeo-dev.spacy"
       - "corpus/ner/archaeo-test.spacy"
-  
+
   - name: "inspect-archaeo"
     help: "Analyze span-characteristics"
     script:
@@ -696,7 +694,7 @@ commands:
         python -m spacy debug data configs/spancat_default.cfg 
         --paths.train corpus/spancat/archaeo-train.spacy 
         --paths.dev corpus/spancat/archaeo-dev.spacy
-  
+
   - name: "clean-archaeo"
     script:
       - mv corpus/ner/archaeo.spacy assets/archaeo_ner.spacy
@@ -726,7 +724,6 @@ commands:
       - corpus/spancat/anem-train.spacy
       - corpus/spancat/anem-dev.spacy
       - corpus/spancat/anem-test.spacy
-  
 
   - name: "convert-anem-ents"
     help: "Convert AnEM dataset into the spaCy format"
@@ -752,7 +749,7 @@ commands:
       - corpus/ner/anem-train.spacy
       - corpus/ner/anem-dev.spacy
       - corpus/ner/anem-test.spacy
-  
+
   - name: "inspect-anem"
     help: "Analyze span-characteristics"
     script:
@@ -763,7 +760,7 @@ commands:
       - python scripts/analyze.py anem en_core_web_sm train
       - python scripts/analyze.py anem en_core_web_sm dev
       - python scripts/analyze.py anem en_core_web_sm test
-  
+
   - name: "unpack-finer"
     help: "Prepare the FiNER dataset."
     script:
@@ -827,7 +824,7 @@ commands:
         python -m spacy debug data configs/spancat_default.cfg 
         --paths.train corpus/spancat/finer-train.spacy 
         --paths.dev corpus/spancat/finer-dev.spacy
-  
+
   - name: "generate-unseen"
     help: "Create unseen entities splits for all preprocessed datasets."
     script:


### PR DESCRIPTION
Before, running the command results into an error:


```
λ: spacy project run conll
ℹ Running workflow 'conll'

================================ unpack-conll ================================
Running command: mkdir temp
Running command: tar -xvf assets/conll.tgz -C temp
ner/bin/
ner/bin/conlleval.txt
ner/bin/sbreaks.txt
ner/bin/chrep.txt
ner/bin/baseline.txt
ner/example.pdf
ner/example.ps
ner/example.tex
ner/index.html
ner/data/esp.testa.gz
ner/data/esp.testb.gz
ner/data/esp.train.gz
ner/data/ned.testa.gz
ner/data/ned.testb.gz
ner/data/ned.train.gz
ner/data/000README
ner/data/OldFiles/ned.testa.gz
ner/data/OldFiles/ned.testb.gz
ner/data/OldFiles/ned.train.gz
Running command: gzip -d temp/ner/data/esp.testa.gz
Running command: gzip -d temp/ner/data/esp.testb.gz
Running command: gzip -d temp/ner/data/esp.train.gz
Running command: gzip -d temp/ner/data/ned.testa.gz
Running command: gzip -d temp/ner/data/ned.testb.gz
Running command: gzip -d temp/ner/data/ned.train.gz
Running command: iconv -f iso-8859-1 temp/ner/data/ned.testa -o assets/nl-conll-dev.iob
iconv: illegal input sequence at position 305

```

Here, I'm specifying the `latin1` encoding and explicitly passing the output encoding. I am not sure why `latin1` works while `iso 8859-1` does not (even if they're technically the same). 

Running the `conll` workflow should give the correct documents:

```python
import spacy
nlp = spacy.blank("nl")
db = DocBin().get_docs("corpus/ner/nl-conll-train.spacy")
docs = list(db.get_docs(nlp.vocab))

docs[0]
```

Gives:

```
 De tekst van het arrest is nog niet schriftelijk beschikbaar maar het bericht werd alvast bekendgemaakt door een communicatiebureau dat Floralux inhuurde . In '81 regulariseert de toenmalige Vlaamse regering de toestand met een BPA dat het bedrijf op eigen kosten heeft laten opstellen . publicatie Vandaag is Floralux dus met alle vergunningen in orde , maar het BPA waarmee die konden verkregen worden , was omstreden omdat zaakvoerster Christiane Vandenbussche haar schepenambt van ... In eerste aanleg werd Vandenbussche begin de jaren '90 veroordeeld wegens belangenvermenging maar later vrijgesproken door het hof van beroep in Gent . SP zit moeilijk -- ( Eric , sd ) Derycke wil BPA goedkeuren op voorwaarde dat BPA ' De Hoogte ' beperkt wordt aanvaard ( burgemeester van Moorslede Walter Ghekiere zal 'n voorstel doen ) . Onvoldoende om een zware straf uit te spreken , luidt het . Dit hof verbindt nu geen straf aan de schuld die ze vaststelt . Die groeit al snel uit tot een heus tuincentrum . pagina Er worden veel meer zaken verkocht dan je in een plantenkwekerij zou verwachten . Dat blijkt overduidelijk uit een fax die haar advocaat destijds aan haar schreef en die bij een huiszoeking in beslag genomen werd . Het dossier gaat terug tot eind de jaren ' 80 . Sybille Decoo Ruimtelijke Ordening zou hebben misbruikt om het BPA te verkrijgen . Het enige bewijs dat overbleef om Vandenbussche te veroordelen voor ' belangenneming ' was haar aanwezigheid op het schepencollege toen het dossier-Floralux aan bod kwam . Eind '98 maakt de Vlaamse regering deze regularisatie definitief met een gewestplanwijziging . Schuld maar geen boete . " Zelf deed hij dit af als " larie en apekool van kwatongen " . De Morgen Vijgen na Pasen , zo lijkt het hof van beroep te hebben gedacht . Antwerpen / Brussel Plaatselijk wordt vermoed dat Floralux de kiescampagnes van Luc Martens financierde , die binnen de vorige regering nog " aandacht " vroeg voor de zaak . Het Leven Vandenbussche zelf besloot dat het hof " de politieke zeden uit het verleden " heeft willen veroordelen . " Het Hof van Cassatie verbrak het arrest zodat het moest worden overgedaan door het hof van beroep van Antwerpen . Dat is het wezen van het arrest dat het Antwerpse hof van beroep woensdag geveld heeft in de zaak van het omstreden tuincentrum Floralux uit Moorslede-Dadizele . Zaakvoerster Christiane Vandenbussche wordt schuldig bevonden aan belangenvermenging ( ' belangenneming ' in juridische taal ) maar krijgt geen straf omdat een straf na al die jaren niet meer zinvol zou zijn . Het is alvast de interpretatie die in de omgeving van Floralux gegeven wordt aan het arrest ( zie pagina 1 ) : dat er een ' nieuwe politieke cultuur ' is aangebroken en de oude politieke zeden weliswaar verwerpelijk waren maar nu niet meer hoeven te worden beboet met , in casu , de sluiting van een zaak . Wat jaren meeging als een omstreden ' CVP-dossier ' krijgt nu door de rechterlijke uitspraak het cachet van een oude koe in de gracht . Om te kunnen voortbestaan wil Floralux dat de landbouwgrond wordt omgezet in kmo-zone . ' Hof veroordeelde politieke zeden van toen ' De advocaat schrijft dat " ( ... ) het dan duidelijk is dat het ( BPA , sd ) enkel voor private doeleinden , namelijk voor uw firma , werd gerealiseerd en het schepencollege als gangmaker daarvoor fungeert " . Niettemin hield ze tegenover de VRT-radio vol dat ze " niets misdaan " heeft . auteur Verder blijkt dat er overleg over plaatsvond met de liberale partij ( toen nog PVV ) ?n met de SP : " Waltniel ( PVV , sd ) is voor . En Delcroix besloot : " Zal erdoor komen . publicatiedatum Die context zorgde ervoor dat het dossier steeds gebaad heeft in een sfeer van partijfinanciering in ruil voor regularisering . Algemeen Dossier steeds geassocieerd met partijfinanciering in ruil voor regularisering Floralux verkrijgt een vergunning om een plantenkwekerij op te trekken . " vrijdag , 2 juni 2000 Het Antwerpse hof weerde het document als bewijsmateriaal maar las het wel voor tijdens de zitting . Wat die politieke zeden waren , valt af te leiden uit de Atoma-schriftjes die Leo Delcroix bijhield toen hij nog CVP-secretaris was . sectie Sybille Decoo Zaakvoerster Floralux houdt vol dat ze niets misdaan heeft Over Floralux stond er : " Ze willen regularisering . editie
```