### PR TITLE
Remove WikiNEuRal dataset

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -24,10 +24,6 @@ workflows:
     - "convert-wnut17-ents"
     - "convert-wnut17-spans"
     - "inspect-wnut17"
-  wikineural:
-    - "clean-wikineural"
-    - "convert-wikineural-ents"
-    - "convert-wikineural-spans"
   conll:
     - "unpack-conll"
     - "preprocess-conll"
@@ -52,9 +48,6 @@ workflows:
     - "preprocess-wnut17"
     - "convert-wnut17-ents"
     - "convert-wnut17-spans"
-    - "clean-wikineural"
-    - "convert-wikineural-ents"
-    - "convert-wikineural-spans"
     - "unpack-conll"
     - "convert-conll-spans"
     - "convert-conll-ents"
@@ -75,47 +68,6 @@ assets:
     url: "https://github.com/leondz/emerging_entities_17/blob/master/emerging.test.annotated"
   - dest: "assets/wnut17-dev.iob"
     url: "https://github.com/leondz/emerging_entities_17/blob/master/emerging.dev.conll"
-  ### Wikineural datasets https://aclanthology.org/2021.findings-emnlp.215/ ###
-  # Wikineural (en)
-  - dest: "assets/raw-en-wikineural-train.iob"
-    description: "WikiNeural (en) training dataset from Tedeschi et al. (EMNLP 2021)"
-    url: https://github.com/Babelscape/wikineural/blob/master/data/wikineural/en/train.conllu
-  - dest: "assets/raw-en-wikineural-dev.iob"
-    description: "WikiNeural (en) dev dataset from Tedeschi et al. (EMNLP 2021)"
-    url: https://github.com/Babelscape/wikineural/blob/master/data/wikineural/en/val.conllu
-  - dest: "assets/raw-en-wikineural-test.iob"
-    description: "WikiNeural (en) test dataset from Tedeschi et al. (EMNLP 2021)"
-    url: https://github.com/Babelscape/wikineural/blob/master/data/wikineural/en/test.conllu
-  # Wikineural (de)
-  - dest: "assets/raw-de-wikineural-train.iob"
-    description: "WikiNeural (de) training dataset from Tedeschi et al. (EMNLP 2021)"
-    url: https://github.com/Babelscape/wikineural/blob/master/data/wikineural/de/train.conllu
-  - dest: "assets/raw-de-wikineural-dev.iob"
-    description: "WikiNeural (de) dev dataset from Tedeschi et al. (EMNLP 2021)"
-    url: https://github.com/Babelscape/wikineural/blob/master/data/wikineural/de/val.conllu
-  - dest: "assets/raw-de-wikineural-test.iob"
-    description: "WikiNeural (de) test dataset from Tedeschi et al. (EMNLP 2021)"
-    url: https://github.com/Babelscape/wikineural/blob/master/data/wikineural/de/test.conllu
-  # Wikineural (es)
-  - dest: "assets/raw-es-wikineural-train.iob"
-    description: "WikiNeural (es) training dataset from Tedeschi et al. (EMNLP 2021)"
-    url: https://github.com/Babelscape/wikineural/blob/master/data/wikineural/es/train.conllu
-  - dest: "assets/raw-es-wikineural-dev.iob"
-    description: "WikiNeural (es) dev dataset from Tedeschi et al. (EMNLP 2021)"
-    url: https://github.com/Babelscape/wikineural/blob/master/data/wikineural/es/val.conllu
-  - dest: "assets/raw-es-wikineural-test.iob"
-    description: "WikiNeural (es) test dataset from Tedeschi et al. (EMNLP 2021)"
-    url: https://github.com/Babelscape/wikineural/blob/master/data/wikineural/es/test.conllu
-  # Wikineural (nl)
-  - dest: "assets/raw-nl-wikineural-train.iob"
-    description: "WikiNeural (nl) training dataset from Tedeschi et al. (EMNLP 2021)"
-    url: https://github.com/Babelscape/wikineural/blob/master/data/wikineural/nl/train.conllu
-  - dest: "assets/raw-nl-wikineural-dev.iob"
-    description: "WikiNeural (nl) dev dataset from Tedeschi et al. (EMNLP 2021)"
-    url: https://github.com/Babelscape/wikineural/blob/master/data/wikineural/nl/val.conllu
-  - dest: "assets/raw-nl-wikineural-test.iob"
-    description: "WikiNeural (nl) test dataset from Tedeschi et al. (EMNLP 2021)"
-    url: https://github.com/Babelscape/wikineural/blob/master/data/wikineural/nl/test.conllu
   # CoNLL-2002 (es, nl) https://aclanthology.org/W02-2024/
   - dest: "assets/conll.tgz"
     description: "ConLL 2002 shared task data."
@@ -133,9 +85,7 @@ assets:
   - dest: "assets/finer139.zip"
     url: "https://huggingface.co/datasets/nlpaueb/finer-139/resolve/main/finer139.zip"
 
-
 commands:
-
   - name: "preprocess-wnut17"
     help: "Canonicalize the WNUT2017 data set for conversion to .spacy."
     script:
@@ -150,7 +100,7 @@ commands:
       - assets/wnut17-train.iob
       - assets/wnut17-dev.iob
       - assets/wnut17-test.iob
-      
+
   - name: "convert-wnut17-ents"
     help: "Convert WNUT17 dataset into the spaCy format"
     script:
@@ -207,304 +157,12 @@ commands:
         --paths.train corpus/spancat/wnut17-train.spacy 
         --paths.dev corpus/spancat/wnut17-dev.spacy
 
-  - name: "clean-wikineural"
-    help: "Remove unnecessary indices from wikineural data"
-    script:
-      # Clean Wikineural datasets
-      - >- 
-        python -m scripts.preprocess
-        assets/raw-de-wikineural-train.iob
-        assets/de-wikineural-train.iob
-        --strip-digits
-      - >-
-        python -m scripts.preprocess
-        assets/raw-de-wikineural-dev.iob
-        assets/de-wikineural-dev.iob
-        --strip-digits
-      - >-
-        python -m scripts.preprocess
-        assets/raw-de-wikineural-test.iob
-        assets/de-wikineural-test.iob
-        --strip-digits
-      - >-
-        python -m scripts.preprocess
-        assets/raw-en-wikineural-train.iob
-        assets/en-wikineural-train.iob
-        --strip-digits
-      - >- 
-        python -m scripts.preprocess
-        assets/raw-en-wikineural-dev.iob
-        assets/en-wikineural-dev.iob
-        --strip-digits
-      - >-
-        python -m scripts.preprocess
-        assets/raw-en-wikineural-test.iob
-        assets/en-wikineural-test.iob
-        --strip-digits
-      - >- 
-        python -m scripts.preprocess
-        assets/raw-es-wikineural-train.iob
-        assets/es-wikineural-train.iob
-        --strip-digits
-      - >-
-        python -m scripts.preprocess
-        assets/raw-es-wikineural-dev.iob
-        assets/es-wikineural-dev.iob
-        --strip-digits
-      - >- 
-        python -m scripts.preprocess
-        assets/raw-es-wikineural-test.iob
-        assets/es-wikineural-test.iob
-        --strip-digits
-      - >- 
-        python -m scripts.preprocess
-        assets/raw-nl-wikineural-train.iob
-        assets/nl-wikineural-train.iob
-        --strip-digits
-      - >- 
-        python -m scripts.preprocess
-        assets/raw-nl-wikineural-dev.iob
-        assets/nl-wikineural-dev.iob
-      - >-
-        python -m scripts.preprocess
-        assets/raw-nl-wikineural-test.iob
-        assets/nl-wikineural-test.iob
-        --strip-digits
-    deps:
-      # Wikineural datasets
-      - assets/raw-de-wikineural-train.iob
-      - assets/raw-de-wikineural-dev.iob
-      - assets/raw-de-wikineural-test.iob
-      - assets/raw-en-wikineural-train.iob
-      - assets/raw-en-wikineural-dev.iob
-      - assets/raw-en-wikineural-test.iob
-      - assets/raw-es-wikineural-train.iob
-      - assets/raw-es-wikineural-dev.iob
-      - assets/raw-es-wikineural-test.iob
-      - assets/raw-nl-wikineural-train.iob
-      - assets/raw-nl-wikineural-dev.iob
-      - assets/raw-nl-wikineural-test.iob
-    outputs:
-      # Cleaned Wikineural datasets
-      - assets/de-wikineural-train.iob
-      - assets/de-wikineural-dev.iob
-      - assets/de-wikineural-test.iob
-      - assets/en-wikineural-train.iob
-      - assets/en-wikineural-dev.iob
-      - assets/en-wikineural-test.iob
-      - assets/es-wikineural-train.iob
-      - assets/es-wikineural-dev.iob
-      - assets/es-wikineural-test.iob
-      - assets/nl-wikineural-train.iob
-      - assets/nl-wikineural-dev.iob
-      - assets/nl-wikineural-test.iob
-
-  - name: "convert-wikineural-spans"
-    help: "Convert WikiNeural dataset (de, en, es, nl) into the spaCy format"
-    script:
-      - >-
-        python -m scripts.convert_to_spans
-        assets/de-wikineural-train.iob corpus/spancat/
-        --spans-key ${vars.spans_key}
-        --converter auto
-      - >-
-        python -m scripts.convert_to_spans
-        assets/de-wikineural-dev.iob corpus/spancat/
-        --spans-key ${vars.spans_key}
-        --converter auto
-      - >-
-        python -m scripts.convert_to_spans
-        assets/de-wikineural-test.iob corpus/spancat/
-        --spans-key ${vars.spans_key}
-        --converter auto
-      - >-
-        python -m scripts.convert_to_spans
-        assets/en-wikineural-train.iob corpus/spancat/
-        --spans-key ${vars.spans_key}
-        --converter auto
-      - >-
-        python -m scripts.convert_to_spans
-        assets/en-wikineural-dev.iob corpus/spancat/
-        --spans-key ${vars.spans_key}
-        --converter auto
-      - >-
-        python -m scripts.convert_to_spans
-        assets/en-wikineural-test.iob corpus/spancat/
-        --spans-key ${vars.spans_key}
-        --converter auto
-      - >-
-        python -m scripts.convert_to_spans
-        assets/es-wikineural-train.iob corpus/spancat/
-        --spans-key ${vars.spans_key}
-        --converter auto
-      - >-
-        python -m scripts.convert_to_spans
-        assets/es-wikineural-dev.iob corpus/spancat/
-        --spans-key ${vars.spans_key}
-        --converter auto
-      - >-
-        python -m scripts.convert_to_spans
-        assets/es-wikineural-test.iob corpus/spancat/
-        --spans-key ${vars.spans_key}
-        --converter auto
-      - >-
-        python -m scripts.convert_to_spans
-        assets/nl-wikineural-train.iob corpus/spancat/
-        --spans-key ${vars.spans_key}
-        --converter auto
-      - >-
-        python -m scripts.convert_to_spans
-        assets/nl-wikineural-dev.iob corpus/spancat/
-        --spans-key ${vars.spans_key}
-        --converter auto
-      - >-
-        python -m scripts.convert_to_spans
-        assets/nl-wikineural-test.iob corpus/spancat/
-        --spans-key ${vars.spans_key}
-        --converter auto
-    deps:
-      - "assets/de-wikineural-train.iob"
-      - "assets/de-wikineural-dev.iob"
-      - "assets/de-wikineural-test.iob"
-      - "assets/en-wikineural-train.iob"
-      - "assets/en-wikineural-dev.iob"
-      - "assets/en-wikineural-test.iob"
-      - "assets/es-wikineural-train.iob"
-      - "assets/es-wikineural-dev.iob"
-      - "assets/es-wikineural-test.iob"
-      - "assets/nl-wikineural-train.iob"
-      - "assets/nl-wikineural-dev.iob"
-      - "assets/nl-wikineural-test.iob"
-    outputs:
-      - "corpus/spancat/de-wikineural-train.spacy"
-      - "corpus/spancat/de-wikineural-dev.spacy"
-      - "corpus/spancat/de-wikineural-test.spacy"
-      - "corpus/spancat/en-wikineural-train.spacy"
-      - "corpus/spancat/en-wikineural-dev.spacy"
-      - "corpus/spancat/en-wikineural-test.spacy"
-      - "corpus/spancat/es-wikineural-train.spacy"
-      - "corpus/spancat/es-wikineural-dev.spacy"
-      - "corpus/spancat/es-wikineural-test.spacy"
-      - "corpus/spancat/nl-wikineural-train.spacy"
-      - "corpus/spancat/nl-wikineural-dev.spacy"
-      - "corpus/spancat/nl-wikineural-test.spacy"
-
-  - name: "convert-wikineural-ents"
-    help: "Convert WikiNeural dataset (de, en, es, nl) into the spaCy format"
-    script:
-      # Convert de dataset
-      - >-
-        python -m scripts.convert_to_spans
-        assets/de-wikineural-train.iob corpus/ner/
-        --use-ents
-      - >-
-        python -m scripts.convert_to_spans
-        assets/de-wikineural-dev.iob corpus/ner/
-        --use-ents
-      - >-
-        python -m scripts.convert_to_spans
-        assets/de-wikineural-test.iob corpus/ner/
-        --use-ents
-      - >-
-        python -m scripts.convert_to_spans
-        assets/de-wikineural-test.iob corpus/spancat/
-        --use-ents
-      # Convert en dataset
-      - >-
-        python -m scripts.convert_to_spans
-        assets/en-wikineural-train.iob corpus/ner/
-        --use-ents
-      - >-
-        python -m scripts.convert_to_spans
-        assets/en-wikineural-dev.iob corpus/ner/
-        --use-ents
-      - >-
-        python -m scripts.convert_to_spans
-        assets/en-wikineural-test.iob corpus/ner/
-        --use-ents
-      # Convert es dataset
-      - >-
-        python -m scripts.convert_to_spans
-        assets/es-wikineural-train.iob corpus/ner/
-        --use-ents
-      - >-
-        python -m scripts.convert_to_spans
-        assets/es-wikineural-dev.iob corpus/ner/
-        --use-ents
-      - >-
-        python -m scripts.convert_to_spans
-        assets/es-wikineural-test.iob corpus/ner/
-        --use-ents
-      # Convert nl dataset
-      - >-
-        python -m scripts.convert_to_spans
-        assets/nl-wikineural-train.iob corpus/ner/
-        --use-ents
-      - >-
-        python -m scripts.convert_to_spans
-        assets/nl-wikineural-dev.iob corpus/ner/
-        --use-ents
-      - >-
-        python -m scripts.convert_to_spans
-        assets/nl-wikineural-test.iob corpus/ner/
-        --use-ents
-    deps:
-      - "assets/de-wikineural-train.iob"
-      - "assets/de-wikineural-dev.iob"
-      - "assets/de-wikineural-test.iob"
-      - "assets/en-wikineural-train.iob"
-      - "assets/en-wikineural-dev.iob"
-      - "assets/en-wikineural-test.iob"
-      - "assets/es-wikineural-train.iob"
-      - "assets/es-wikineural-dev.iob"
-      - "assets/es-wikineural-test.iob"
-      - "assets/nl-wikineural-train.iob"
-      - "assets/nl-wikineural-dev.iob"
-      - "assets/nl-wikineural-test.iob"
-    outputs:
-      - "corpus/ner/de-wikineural-train.spacy"
-      - "corpus/ner/de-wikineural-dev.spacy"
-      - "corpus/spancat/de-wikineural-test.spacy"
-      - "corpus/ner/en-wikineural-train.spacy"
-      - "corpus/ner/en-wikineural-dev.spacy"
-      - "corpus/ner/en-wikineural-test.spacy"
-      - "corpus/ner/es-wikineural-train.spacy"
-      - "corpus/ner/es-wikineural-dev.spacy"
-      - "corpus/ner/es-wikineural-test.spacy"
-      - "corpus/ner/nl-wikineural-train.spacy"
-      - "corpus/ner/nl-wikineural-dev.spacy"
-      - "corpus/ner/nl-wikineural-test.spacy"
-  
-  - name: "inspect-wikineural"
-    help: "Analyze span-characteristics"
-    script:
-      - >-
-        python -m spacy debug data configs/spancat_default.cfg 
-        --paths.train corpus/spancat/de-wikineural-train.spacy 
-        --paths.dev corpus/spancat/de-wikineural-dev.spacy
-      
-      - >-
-        python -m spacy debug data configs/spancat_default.cfg 
-        --paths.train corpus/spancat/en-wikineural-train.spacy 
-        --paths.dev corpus/spancat/en-wikineural-dev.spacy
-      
-      - >-
-        python -m spacy debug data configs/spancat_default.cfg 
-        --paths.train corpus/spancat/es-wikineural-train.spacy 
-        --paths.dev corpus/spancat/es-wikineural-dev.spacy
-      
-      - >-
-        python -m spacy debug data configs/spancat_default.cfg 
-        --paths.train corpus/spancat/nl-wikineural-train.spacy 
-        --paths.dev corpus/spancat/nl-wikineural-dev.spacy
-
-
   - name: "unpack-conll"
     help: "Decompress ConLL 2002, remove temporary files and change encoding."
     script:
       - mkdir temp
       - tar -xvf assets/conll.tgz -C temp
-      - gzip -d temp/ner/data/esp.testa.gz 
+      - gzip -d temp/ner/data/esp.testa.gz
       - gzip -d temp/ner/data/esp.testb.gz
       - gzip -d temp/ner/data/esp.train.gz
       - gzip -d temp/ner/data/ned.testa.gz
@@ -528,7 +186,7 @@ commands:
       - assets/nl-conll-train.iob
       - assets/nl-conll-dev.iob
       - assets/nl-conll-test.iob
-  
+
   - name: "preprocess-conll"
     help: "Canonicalize the Dutch ConLL data set for conversion to .spacy."
     script:
@@ -637,7 +295,7 @@ commands:
       - "corpus/ner/nl-conll-train.spacy"
       - "corpus/ner/nl-conll-dev.spacy"
       - "corpus/ner/nl-conll-test.spacy"
-  
+
   - name: "inspect-conll"
     help: "Analyze span-characteristics"
     script:
@@ -689,7 +347,7 @@ commands:
       - "corpus/ner/archaeo-train.spacy"
       - "corpus/ner/archaeo-dev.spacy"
       - "corpus/ner/archaeo-test.spacy"
-  
+
   - name: "inspect-archaeo"
     help: "Analyze span-characteristics"
     script:
@@ -697,7 +355,7 @@ commands:
         python -m spacy debug data configs/spancat_default.cfg 
         --paths.train corpus/spancat/archaeo-train.spacy 
         --paths.dev corpus/spancat/archaeo-dev.spacy
-  
+
   - name: "clean-archaeo"
     script:
       - mv corpus/ner/archaeo.spacy assets/archaeo_ner.spacy
@@ -727,7 +385,6 @@ commands:
       - corpus/spancat/anem-train.spacy
       - corpus/spancat/anem-dev.spacy
       - corpus/spancat/anem-test.spacy
-  
 
   - name: "convert-anem-ents"
     help: "Convert AnEM dataset into the spaCy format"
@@ -753,7 +410,7 @@ commands:
       - corpus/ner/anem-train.spacy
       - corpus/ner/anem-dev.spacy
       - corpus/ner/anem-test.spacy
-  
+
   - name: "inspect-anem"
     help: "Analyze span-characteristics"
     script:
@@ -764,7 +421,7 @@ commands:
       - python scripts/analyze.py anem en_core_web_sm train
       - python scripts/analyze.py anem en_core_web_sm dev
       - python scripts/analyze.py anem en_core_web_sm test
-  
+
   - name: "unpack-finer"
     help: "Prepare the FiNER dataset."
     script:
@@ -828,7 +485,7 @@ commands:
         python -m spacy debug data configs/spancat_default.cfg 
         --paths.train corpus/spancat/finer-train.spacy 
         --paths.dev corpus/spancat/finer-dev.spacy
-  
+
   - name: "generate-unseen"
     help: "Create unseen entities splits for all preprocessed datasets."
     script:


### PR DESCRIPTION
Because it's silver-standard, and performance is negligible either way.